### PR TITLE
fix(cors): setAllowedOriginPatterns으로 교체 — Vercel 프리뷰 URL 와일드카드 지원

### DIFF
--- a/src/main/java/com/attestry/dpp/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/attestry/dpp/infrastructure/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         // application.yml의 cors.allowed-origins 또는 환경변수 CORS_ALLOWED_ORIGINS에서 읽음
-        configuration.setAllowedOrigins(Arrays.stream(allowedOrigins.split(","))
+        configuration.setAllowedOriginPatterns(Arrays.stream(allowedOrigins.split(","))
                 .map(String::trim)
                 .toList());
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));


### PR DESCRIPTION
setAllowedOrigins()는 allowCredentials(true)와 * 조합 불가, 패턴 와일드카드 미지원. setAllowedOriginPatterns()로 교체하여
CORS_ALLOWED_ORIGINS에 https://*.vercel.app 패턴 사용 가능.