### PR TITLE
fix: return signed GET evidence URLs for admin and passport views

### DIFF
--- a/src/main/java/com/attestry/dpp/application/port/FileReadUrlPort.java
+++ b/src/main/java/com/attestry/dpp/application/port/FileReadUrlPort.java
@@ -1,0 +1,5 @@
+package com.attestry.dpp.application.port;
+
+public interface FileReadUrlPort {
+    String createPresignedReadUrl(String rawUrlOrObjectPath);
+}

--- a/src/main/java/com/attestry/dpp/application/usecase/query/PassportQueryUseCaseHandler.java
+++ b/src/main/java/com/attestry/dpp/application/usecase/query/PassportQueryUseCaseHandler.java
@@ -2,6 +2,7 @@ package com.attestry.dpp.application.usecase.query;
 
 import com.attestry.dpp.application.dto.result.PassportMyPassportResult;
 import com.attestry.dpp.application.dto.result.PassportPublicViewResult;
+import com.attestry.dpp.application.port.FileReadUrlPort;
 import com.attestry.dpp.domain.model.*;
 import com.attestry.dpp.domain.repository.*;
 import com.attestry.dpp.domain.exception.*;
@@ -33,6 +34,7 @@ public class PassportQueryUseCaseHandler implements PassportQueryUseCase {
         private final OwnershipRepository ownershipRepository;
         private final UserRepository userRepository;
         private final RegistrationRepository registrationRepository;
+        private final FileReadUrlPort fileReadUrlPort;
 
         /**
          * QR 공개 코드로 공개 인증서를 조회합니다.
@@ -121,7 +123,8 @@ public class PassportQueryUseCaseHandler implements PassportQueryUseCase {
                 if (requests.isEmpty()) {
                         return null;
                 }
-                return EvidenceUrlParser.firstOrNull(requests.get(0).getEvidenceUrls());
+                String rawUrl = EvidenceUrlParser.firstOrNull(requests.get(0).getEvidenceUrls());
+                return fileReadUrlPort.createPresignedReadUrl(rawUrl);
         }
 
         /**

--- a/src/main/java/com/attestry/dpp/application/usecase/query/RegistrationQueryUseCaseHandler.java
+++ b/src/main/java/com/attestry/dpp/application/usecase/query/RegistrationQueryUseCaseHandler.java
@@ -1,21 +1,29 @@
 package com.attestry.dpp.application.usecase.query;
 
 import com.attestry.dpp.application.dto.result.RegistrationRequestResult;
+import com.attestry.dpp.application.port.FileReadUrlPort;
 import com.attestry.dpp.application.usecase.query.RegistrationQueryUseCase;
 import com.attestry.dpp.domain.model.RegistrationRequest;
 import com.attestry.dpp.domain.model.RegistrationStatus;
 import com.attestry.dpp.domain.repository.RegistrationRepository;
+import com.attestry.dpp.domain.util.EvidenceUrlParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class RegistrationQueryUseCaseHandler implements RegistrationQueryUseCase {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final RegistrationRepository registrationRepository;
+    private final FileReadUrlPort fileReadUrlPort;
 
     /**
      * 관리자용 대기(PENDING) 등록 요청 목록을 페이지로 조회합니다.
@@ -40,9 +48,32 @@ public class RegistrationQueryUseCaseHandler implements RegistrationQueryUseCase
                 entity.getRequestId(),
                 entity.getModelName(),
                 entity.getSerialNumber(),
-                entity.getEvidenceUrls(),
+                toDisplayEvidenceUrls(entity.getEvidenceUrls()),
                 entity.getRequesterId(),
                 entity.getStatus().name(),
                 entity.getCreatedAt());
+    }
+
+    private String toDisplayEvidenceUrls(String rawEvidenceUrls) {
+        if (rawEvidenceUrls == null || rawEvidenceUrls.isBlank()) {
+            return rawEvidenceUrls;
+        }
+        List<String> parsed = EvidenceUrlParser.parse(rawEvidenceUrls);
+        if (parsed.isEmpty()) {
+            return rawEvidenceUrls;
+        }
+
+        List<String> signed = parsed.stream()
+                .map(fileReadUrlPort::createPresignedReadUrl)
+                .toList();
+
+        if (rawEvidenceUrls.trim().startsWith("[")) {
+            try {
+                return OBJECT_MAPPER.writeValueAsString(signed);
+            } catch (Exception ignored) {
+                return rawEvidenceUrls;
+            }
+        }
+        return signed.get(0);
     }
 }

--- a/src/main/java/com/attestry/dpp/infrastructure/storage/MinioStorageAdapter.java
+++ b/src/main/java/com/attestry/dpp/infrastructure/storage/MinioStorageAdapter.java
@@ -1,6 +1,7 @@
 package com.attestry.dpp.infrastructure.storage;
 
 import com.attestry.dpp.application.port.FileUploadUrlPort;
+import com.attestry.dpp.application.port.FileReadUrlPort;
 import com.attestry.dpp.domain.exception.CustomException;
 import com.attestry.dpp.domain.exception.ErrorCode;
 import io.minio.BucketExistsArgs;
@@ -13,12 +14,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
-public class MinioStorageAdapter implements FileUploadUrlPort {
+public class MinioStorageAdapter implements FileUploadUrlPort, FileReadUrlPort {
 
     private MinioClient minioClient;
     private MinioClient presignMinioClient;
@@ -78,6 +80,49 @@ public class MinioStorageAdapter implements FileUploadUrlPort {
         } catch (Exception e) {
             // 외부 스토리지 예외는 도메인 공통 예외 포맷으로 변환
             throw new CustomException(ErrorCode.INTERNAL_ERROR, "Error generating pre-signed URL: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String createPresignedReadUrl(String rawUrlOrObjectPath) {
+        if (!hasText(rawUrlOrObjectPath)) {
+            return rawUrlOrObjectPath;
+        }
+        String objectName = extractObjectName(rawUrlOrObjectPath);
+        if (!hasText(objectName)) {
+            return rawUrlOrObjectPath;
+        }
+
+        try {
+            return presignMinioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.GET)
+                            .bucket(bucketName)
+                            .object(objectName)
+                            .expiry(15, TimeUnit.MINUTES)
+                            .build());
+        } catch (Exception e) {
+            log.warn("증빙 이미지 조회 URL 생성 실패. 원본 URL 반환: {}", e.getMessage());
+            return rawUrlOrObjectPath;
+        }
+    }
+
+    private String extractObjectName(String rawUrlOrObjectPath) {
+        String value = rawUrlOrObjectPath.trim();
+        try {
+            URI uri = URI.create(value);
+            String path = uri.getPath();
+            if (!hasText(path)) {
+                return value;
+            }
+            String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
+            String bucketPrefix = bucketName + "/";
+            if (normalizedPath.startsWith(bucketPrefix)) {
+                return normalizedPath.substring(bucketPrefix.length());
+            }
+            return normalizedPath;
+        } catch (Exception ignored) {
+            return value;
         }
     }
 

--- a/src/test/java/com/attestry/dpp/application/usecase/PassportQueryUseCaseHandlerTest.java
+++ b/src/test/java/com/attestry/dpp/application/usecase/PassportQueryUseCaseHandlerTest.java
@@ -2,6 +2,7 @@ package com.attestry.dpp.application.usecase;
 
 import com.attestry.dpp.application.dto.result.PassportMyPassportResult;
 import com.attestry.dpp.application.dto.result.PassportPublicViewResult;
+import com.attestry.dpp.application.port.FileReadUrlPort;
 import com.attestry.dpp.application.usecase.query.PassportQueryUseCaseHandler;
 import com.attestry.dpp.domain.exception.NotFoundException;
 import com.attestry.dpp.domain.model.Asset;
@@ -32,6 +33,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +49,8 @@ class PassportQueryUseCaseHandlerTest {
     private UserRepository userRepository;
     @Mock
     private RegistrationRepository registrationRepository;
+    @Mock
+    private FileReadUrlPort fileReadUrlPort;
 
     @InjectMocks
     private PassportQueryUseCaseHandler handler;
@@ -121,6 +125,7 @@ class PassportQueryUseCaseHandlerTest {
         when(ownershipRepository.findByOwnerId("U1", PageRequest.of(0, 5)))
                 .thenReturn(new PageImpl<>(List.of(ownership), PageRequest.of(0, 5), 1));
         when(registrationRepository.findBySerialNumberAndModelName("SN-777", "Model Y")).thenReturn(List.of(request));
+        when(fileReadUrlPort.createPresignedReadUrl(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
 
         Page<PassportMyPassportResult> page = handler.getMyPassports("U1", PageRequest.of(0, 5));
 

--- a/src/test/java/com/attestry/dpp/application/usecase/RegistrationQueryUseCaseHandlerTest.java
+++ b/src/test/java/com/attestry/dpp/application/usecase/RegistrationQueryUseCaseHandlerTest.java
@@ -1,6 +1,7 @@
 package com.attestry.dpp.application.usecase;
 
 import com.attestry.dpp.application.dto.result.RegistrationRequestResult;
+import com.attestry.dpp.application.port.FileReadUrlPort;
 import com.attestry.dpp.application.usecase.query.RegistrationQueryUseCaseHandler;
 import com.attestry.dpp.domain.model.RegistrationRequest;
 import com.attestry.dpp.domain.model.RegistrationStatus;
@@ -26,6 +27,8 @@ class RegistrationQueryUseCaseHandlerTest {
 
     @Mock
     private RegistrationRepository registrationRepository;
+    @Mock
+    private FileReadUrlPort fileReadUrlPort;
 
     @InjectMocks
     private RegistrationQueryUseCaseHandler handler;
@@ -54,4 +57,3 @@ class RegistrationQueryUseCaseHandlerTest {
         assertThat(result.getContent().get(0).getStatus()).isEqualTo("PENDING");
     }
 }
-


### PR DESCRIPTION
return signed GET evidence URLs for admin and passport views